### PR TITLE
Fix hwp.js initialization for preview

### DIFF
--- a/sign_hwp/src/lib/hwp/parseHwp.ts
+++ b/sign_hwp/src/lib/hwp/parseHwp.ts
@@ -1,9 +1,20 @@
 // src/lib/hwp/parseHwp.ts
+import * as HWP from 'hwp.js';
+
+let readyPromise: Promise<void> | null = null;
+
 export async function parseHwp(buffer: ArrayBuffer): Promise<string> {
-  // @ts-ignore
-  if (!window.HWP || typeof window.HWP.parse !== 'function') {
-    throw new Error('hwp.js가 로드되지 않았거나 parse 함수가 없습니다.');
+  // hwp.js 모듈 초기화 대기
+  if (!readyPromise) {
+    // @ts-ignore - hwp.js는 ready 프로퍼티를 제공
+    readyPromise = HWP.ready instanceof Promise ? HWP.ready : Promise.resolve();
   }
-  // @ts-ignore
-  return await window.HWP.parse(buffer);
-} 
+  await readyPromise;
+
+  if (typeof (HWP as any).parse !== 'function') {
+    throw new Error('hwp.js parse 함수를 찾을 수 없습니다.');
+  }
+
+  // @ts-ignore - parse 반환값은 문자열
+  return HWP.parse(buffer);
+}

--- a/sign_hwp/src/lib/hwp/types.d.ts
+++ b/sign_hwp/src/lib/hwp/types.d.ts
@@ -1,3 +1,4 @@
 declare module 'hwp.js' {
-  export function init(opts: { locateFile: (f: string) => string }): Promise<any>;
-} 
+  export const ready: Promise<void>;
+  export function parse(buffer: ArrayBuffer): string;
+}


### PR DESCRIPTION
## Summary
- load the `hwp.js` module properly
- update hwp.js type definitions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6880898417f48320b9429be16c5395db